### PR TITLE
(KWA-805) ABC 네트워크 Logger 추가

### DIFF
--- a/ABCUtils/Sources/Network/ABCNetworkLogger.swift
+++ b/ABCUtils/Sources/Network/ABCNetworkLogger.swift
@@ -1,0 +1,112 @@
+//
+//  File.swift
+//  ABCSecureChannel
+//
+//  Created by ABCElio on 10/27/25.
+//
+
+import Foundation
+
+public enum LogStyle {
+    case prettyJson, string, none
+}
+
+public enum ABCNetworkLogger {
+    public static func printRequestLog(_ request: URLRequest, logStyle: LogStyle) {
+        #if DEBUG
+        var body: Any?
+        let header = request.allHTTPHeaderFields?.prettyPrintedJSONString ?? "nil"
+        if let data = request.httpBody {
+            switch logStyle {
+            case .prettyJson:
+                body = data.asPrettyJsonString()
+            case .string:
+                body = String(data: data, encoding: .utf8)
+            case .none:
+                body = nil
+            }
+        }
+        let log = """
+        📣 Request Call 📣
+            - url: \(request.url?.absoluteString ?? "")
+            - header: \(header)
+            - method: \(request.httpMethod ?? "")
+            - body: \(body ?? "")
+        """
+        print(log)
+        #endif
+    }
+    
+    public static func printResponseLog(_ response: HTTPURLResponse, data: Data?, logStyle: LogStyle) {
+        #if DEBUG
+        let header = response.allHeaderFields.prettyPrintedJSONString
+        var body: Any?
+        if let data = data {
+            switch logStyle {
+            case .prettyJson:
+                body = data.asPrettyJsonString()
+            case .string:
+                body = String(data: data, encoding: .utf8)
+            case .none:
+                body = nil
+            }
+        }
+        let log = """
+         🔵 Response Successful 🔵
+             - url: \(response.url?.absoluteString ?? "")
+             - header: \(header)
+             - statusCode: \(response.statusCode)
+             - body: \(body ?? "nil")
+         """
+        print(log)
+        #endif
+    }
+    
+    public static func printResponseFailLog(_ response: HTTPURLResponse, data: Data? = nil, logStyle: LogStyle) {
+        #if DEBUG
+        let header = response.allHeaderFields.prettyPrintedJSONString
+        var body: Any?
+        if let data = data {
+            switch logStyle {
+            case .prettyJson:
+                body = data.asPrettyJsonString()
+            case .string:
+                body = String(data: data, encoding: .utf8)
+            case .none:
+                body = nil
+            }
+        }
+        let log = """
+         🔴 Response Failed 🔴
+             - url: \(response.url?.absoluteString ?? "")
+             - header: \(header)
+             - statusCode: \(response.statusCode)
+             - body: \(body ?? "nil")
+         """
+        print(log)
+        #endif
+    }
+}
+
+fileprivate extension Dictionary {
+    var prettyPrintedJSONString: String {
+        guard !isEmpty else { return "nil" }
+        let jsonData = try? JSONSerialization.data(withJSONObject: self, options: [.prettyPrinted])
+        return String(data: jsonData ?? Data(), encoding: .utf8) ?? "nil"
+    }
+}
+
+fileprivate extension Data {
+    
+    func asPrettyJsonString() -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: self) else {
+            return String(data: self, encoding: .utf8)
+        }
+        
+        let prettyJsonData = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted])
+        guard let prettyJsonData else { return .none }
+        return String(data: prettyJsonData, encoding: .utf8)
+    }
+}

--- a/ABCUtils/Sources/Network/URLSession+SugarAPI.swift
+++ b/ABCUtils/Sources/Network/URLSession+SugarAPI.swift
@@ -18,6 +18,7 @@ extension URLSession {
         }
         
         self.dataTask(with: request) { data, response, error in
+            ABCNetworkLogger.printRequestLog(request, logStyle: .prettyJson)
             if let error = error {
                 completion?(.failure(NetworkError.Response.serverError(error)))
                 return
@@ -30,6 +31,7 @@ extension URLSession {
             }
             
             guard let responseData = data else {
+                ABCNetworkLogger.printResponseFailLog(response, logStyle: .prettyJson)
                 completion?(.failure(NetworkError.Response.emptyData))
                 return
             }
@@ -40,14 +42,17 @@ extension URLSession {
                 let status = response.statusCode
                 let errorObject = try? JSONDecoder().decode(ABCNetworkError.self, from: responseData)
                 let error = NetworkError.Response.statusCodeError(status: status, origin: origin, error: errorObject)
+                ABCNetworkLogger.printResponseFailLog(response, data: data, logStyle: .prettyJson)
                 completion?(.failure(error))
                 return
             }
             
             do {
                 let decodeItem = try JSONDecoder().decode(Item.self, from: responseData)
+                ABCNetworkLogger.printResponseLog(response, data: data, logStyle: .prettyJson)
                 completion?(.success(decodeItem))
             } catch {
+                ABCNetworkLogger.printResponseFailLog(response, data: data, logStyle: .prettyJson)
                 completion?(.failure(NetworkError.Response.objectDecodeError(origin: origin)))
             }
         }
@@ -63,6 +68,8 @@ extension URLSession {
         }
         
         self.dataTask(with: request) { data, response, error in
+            ABCNetworkLogger.printRequestLog(request, logStyle: .prettyJson)
+            
             if let error = error {
                 completion?(.failure(NetworkError.Response.serverError(error)))
                 return
@@ -75,6 +82,7 @@ extension URLSession {
             }
             
             guard let responseData = data else {
+                ABCNetworkLogger.printResponseFailLog(response, logStyle: .prettyJson)
                 completion?(.failure(NetworkError.Response.emptyData))
                 return
             }
@@ -85,10 +93,12 @@ extension URLSession {
                 let status = response.statusCode
                 let errorObject = try? JSONDecoder().decode(ABCNetworkError.self, from: responseData)
                 let error = NetworkError.Response.statusCodeError(status: status, origin: origin, error: errorObject)
+                ABCNetworkLogger.printResponseFailLog(response, logStyle: .prettyJson)
                 completion?(.failure(error))
                 return
             }
             
+            ABCNetworkLogger.printResponseLog(response, data: data, logStyle: .prettyJson)
             completion?(.success(()))
         }
         .resume()


### PR DESCRIPTION
## Jira 티켓 링크 (관련 jira 티켓의 링크를 여기에 기록합니다)
- [KWA-805](https://ahnlabio.atlassian.net/jira/software/c/projects/KWA/boards/197/backlog?assignee=712020%3Ad0111fa2-f334-40de-90d4-ee16c98faead&ignoreStickyVersion=true&selectedIssue=KWA-805)
## 변경사항 타입
> 신규기능, 버그픽스, 리팩토링, 설정변경, 버전변경 등
- 신규기능
## 변경사항 요약
- ABCNetworkLogger 객체를 추가하여 네트워크 통신간의 request, response 로그가 출력되게 변경하였습니다.
- LoggerStyle은 PrettyJson으로 출력되게 고정해두었습니다. JSON으로 파싱되지 않을시 String으로 plain하게 출력됩니다.
```swift
public enum LogStyle {
    case prettyJson, string, none
}
```
- 현재는 필요없다고 생각하여 Logger On/Off나, LogStyle변경은 따로 외부에서 접근하여 변경할 수 없게 하였습니다.
- 내부에 존재하는 ABCSecureChannel 테스트 코드를 통해 테스트 완료했습니다.
- 로그 형식은 다음과 같습니다.

```swift
📣 Request Call 📣
    - url: https://baseUrl.com
    - header: {"Content-Type": "application/x-www-form-urlencoded"}
    - method: POST
    - body: nil
```

```swift
🔵 Response Successful 🔵
    - url: https://baseUrl.com
    - header: {"Content-Type": "application/x-www-form-urlencoded"}
    - statusCode: 200
    - body: {
  "channelid" : "1",
  "publickey" : "PublicKey",
  "encrypted" : "ABCDEFG"
}
```

```swift
🔴 Response Failed 🔴
    - url: https://baseUrl.com
    - header: {"Content-Type": "application/x-www-form-urlencoded"}
    - statusCode: 404
    - body: nil
```

[KWA-805]: https://ahnlabio.atlassian.net/browse/KWA-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ